### PR TITLE
turns out the Support API does not support action-level IAM permissio…

### DIFF
--- a/iam/trusted_advisor_role.json
+++ b/iam/trusted_advisor_role.json
@@ -15,7 +15,7 @@
             "Action": [ "sts:AssumeRole" ]
           } ] 
         },
-        "Path": "/Operations",
+        "Path": "/Operations/",
         "Policies": [ 
         {
           "PolicyName" : "TrustedAdvisorAccess",
@@ -25,9 +25,7 @@
             {
               "Effect": "Allow",
               "Action": [
-                "support:DescribeTrustedAdvisorChecks",
-                "support:DescribeTrustedAdvisorCheckResult",
-                "support:DescribeTrustedAdvisorCheckSummaries"
+                "support:*"
               ],
               "Resource": "*"
             }


### PR DESCRIPTION
…ns: http://docs.aws.amazon.com/IAM/latest/UserGuide/reference_aws-services-that-work-with-iam.html#resources_svcs, and require support.*